### PR TITLE
adding directories and files for Tulsa, OK and Leavenworth, WA

### DIFF
--- a/0-csv-files/united_states-leavenworth.csv
+++ b/0-csv-files/united_states-leavenworth.csv
@@ -1,0 +1,2 @@
+who,type,country,state,city,latitude,longitude
+certificate-student,place I've lived,United States,Washington,Leavenworth,47.596389,-120.665278

--- a/0-csv-files/united_states-tulsa.csv
+++ b/0-csv-files/united_states-tulsa.csv
@@ -1,0 +1,2 @@
+who,type,country,state,city,latitude,longitude
+certificate-student,place I live now,United States,Oklahoma,Tulsa,36.156795,-95.991363

--- a/united-states-of-america/oklahoma/tulsa_oklahoma.ipynb
+++ b/united-states-of-america/oklahoma/tulsa_oklahoma.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tulsa, Oklahoma - United States of America\n",
+    "\n",
+    "### Location: 36°09.4' N      95°59.5' W\n",
+    "\n",
+    "### Population: 396,543 (2020) [_Data Source_](https://worldpopulationreview.com/us-cities/tulsa-ok-population)\n",
+    "\n",
+    "### Landmark: Gathering Place\n",
+    "\n",
+    "![Gathering Place aerial view from north](https://assets.speakcdn.com/assets/2511/after_1_1.jpg)\n",
+    "\n",
+    "Gathering Place is a world class riverfront park designed for all to enjoy through programming, interactive play elements and beautiful landscapes. An inclusive space that strives to engage, educate and excite while creating distinct memories for all who gather. (Description from www.gatheringplace.org)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/united-states-of-america/washington/leavenworth_washington.ipynb
+++ b/united-states-of-america/washington/leavenworth_washington.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Leavenworth, Washington - United States of America\n",
+    "\n",
+    "### Location: 47° 35.8′ N     120° 39.9′  W\n",
+    "\n",
+    "### Population: 2,032 (2020) [_Data Source_](https://worldpopulationreview.com/us-cities/leavenworth-wa-population)\n",
+    "\n",
+    "### Landmark: Bavarian village\n",
+    "\n",
+    "![Leavenworth Bavarian facades](https://images.squarespace-cdn.com/content/v1/5475c689e4b05a135b085d65/1545402896507-C65PGRE7QP5DPP317O5R/ke17ZwdGBToddI8pDm48kDW6a-KjYmcPmCKxmIOcRX0UqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYy7Mythp_T-mtop-vrsUOmeInPi9iDjx9w8K4ZfjXt2dqTKZ0PXGZzd37N2c1wfBhjJmjTNv9-oSslRm_axr9iBH3bqxw7fF48mhrq5Ulr0Hg/Leavenworth%2BWashington%2BChristmas%2BLighing%2BFestival.jpg)\n",
+    "\n",
+    "Leavenworth is a major tourism destination located on the eastern side of the Cascades mountain range in Washington State. The alpine setting and architectural style of the town are remarkably reminiscent of Bavaria. The theme town idea was born of a 1960's-era civic initiative to revitalize Leavenworth's economy from that of a struggling logging community to one that capitalized on tourism. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
@lwasser 
Fixes #74 
This fork contains 2 .csv files in the 0-csv-files directory (note: lat long are in dd.ddddd format)
0-csv-files/
united_states-leavenworth.csv
united_states-tulsa.csv

The fork also contains new directory structures and .ipynb files
united-states-of-america/oklahoma/tulsa_oklahoma.ipynb
united-states-of-america/washington/leavenworth_washington.ipynb